### PR TITLE
Scertificate search update

### DIFF
--- a/backend/src/controllers/scertificate.controller.js
+++ b/backend/src/controllers/scertificate.controller.js
@@ -76,17 +76,17 @@ export const viewScertificate = asyncHandler(async (req, res) => {
         return res.status(400).json({ message: "Invalid certificate ID" });
     }
 
-    // Find the certificate by ID and update status to found, if it is still "lost".
+    // Find the certificate by ID and update status to found and claimed, if it is still "lost".
     const certificate = await Scertificate.findOneAndUpdate(
         { _id: id, status: "lost" },
-        { $set: { status: "found", foundAt: new Date() } },
+        { $set: { status: "found", claimed: true, claimedAt: new Date() } },
         { new: true }
     );
 
     if (certificate) {
-        // successfully updated to found — increment found documents stats
-        await Stats.findOneAndUpdate({}, { $inc: { foundDocuments: 1 } }, { upsert: true });
-    } else {
+        // successfully updated to found and claimed — increment found and claimed documents stats
+        await Stats.findOneAndUpdate({}, { $inc: { foundDocuments: 1, claimedDocuments: 1 } }, { upsert: true });
+    }
         //if not found with the status lost, try to find it anyway ( might already be 'found')
         const existingCertificate = await Scertificate.findById(id);
         if (!existingCertificate) {

--- a/backend/src/controllers/scertificate.controller.js
+++ b/backend/src/controllers/scertificate.controller.js
@@ -54,9 +54,10 @@ export const searchScertificate = asyncHandler(async (req, res) => { // Renamed 
     if (certTypeResult.error) return res.status(400).json({ message: certTypeResult.error });
     const canonicalType = certTypeResult.canonical;
 
-    const lastNameResult = getCanonical(lastName, [], 'lastName'); // Assuming no fixed allowed values for lastName
-    if (lastNameResult.error) return res.status(400).json({ message: lastNameResult.error });
-    const canonicalLastName = lastNameResult.canonical;
+    if (!lastName || lastName.trim() === '') {
+        return res.status(400).json({ message: 'lastName is required' });
+    }
+    const canonicalLastName = lastName.trim().toLowerCase();
 
     // Find all school certificates that match the certificate type and last name, including claimed ones.
 
@@ -89,7 +90,7 @@ export const viewScertificate = asyncHandler(async (req, res) => {
 
     if (certificate) {
         // successfully updated to found and claimed — increment found and claimed documents stats
-        await Stats.findOneAndUpdate({}, { $inc: { foundDocuments: 1, claimedDocuments: 1 } }, { upsert: true });
+        await Stats.findOneAndUpdate({}, { $inc: { claimedDocuments: 1 } }, { upsert: true });
 
         // return updated certificate
         const {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now requires certificate type and last name, canonicalizes last names, matches exact canonical last name, and limits results to 10 for more accurate lookup.
  * Claiming a certificate now marks it as found and claimed, records the claim timestamp, and updates claimed-document statistics.
  * API responses return updated certificate data, with a fallback that returns existing data or a 404 when not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->